### PR TITLE
fix: ensure PKCE works for MCP Server auth (#256)

### DIFF
--- a/src/lib/ai/mcp/create-mcp-client.ts
+++ b/src/lib/ai/mcp/create-mcp-client.ts
@@ -90,8 +90,12 @@ export class MCPClient {
       throw new Error("OAuth flow requires a remote MCP server");
 
     if (this.status != "authorizing" || this.oauthProvider?.state() != state) {
-      await this.disconnect();
-      await this.connect(state);
+      if (this.oauthProvider && this.oauthProvider.state() != state) {
+        await this.oauthProvider.adoptState(state);
+      } else {
+        await this.disconnect();
+        await this.connect(state);
+      }
     }
     const finish = (this.transport as StreamableHTTPClientTransport)
       ?.finishAuth;


### PR DESCRIPTION
I encountered `invalid_grant` errors when authorizing our remote MCP server via OAuth. The error message was `Invalid PKCE code_verifier` (right at the end of the OAuth flow)

After some analysis (assisted by Claude) it appears the issue is due to the fact that in serverless environments like Vercel the steps of the OAuth flow may not be handled by the same instance.

I have tested the fix and our MCP Server (https://mcp.cirra.ai/sse) now authorizes without problem on our deployed instance (currently at https://cirra-ai-chatbot.vercel.app/)

-------------------------------------------------------- Detailed explanation and analysis (courtesy of Claude).


## The Bug

Look at this code in `MCPClient.finishAuth()`:

```typescript
async finishAuth(code: string, state: string) {
  if (!isMaybeRemoteConfig(this.serverConfig))
    throw new Error("OAuth flow requires a remote MCP server");

  if (this.status != "authorizing" || this.oauthProvider?.state() != state) {
    await this.disconnect();
    await this.connect(state); // ← This creates a NEW OAuth session!
  }
  // ... rest of the method
}
```

## The Problem

When the callback handler calls `finishAuth(code, state)`:

1. **Condition check**: `this.oauthProvider?.state() != state` 
   - The existing client has state `X` (from when it was first created)
   - The callback provides state `Y` (the actual OAuth callback state)
   - These don't match, so the condition is `true`

2. **Bug occurs**: The method calls `this.connect(state)` which creates a **brand new OAuth session** with the callback state, instead of adopting the existing session

3. **PKCE failure**: The new session has no `code_verifier` stored, or has a different one, causing the PKCE validation to fail

## The Fix

The `finishAuth` method should adopt the existing session, not create a new one. Replace this:

```typescript
if (this.status != "authorizing" || this.oauthProvider?.state() != state) {
  await this.disconnect();
  await this.connect(state); // ❌ Creates new session
}
```

With this:

```typescript
if (this.status != "authorizing" || this.oauthProvider?.state() != state) {
  // ✅ Adopt the existing session instead of creating a new one
  if (this.oauthProvider && this.oauthProvider.state() != state) {
    await this.oauthProvider.adoptState(state);
  } else {
    await this.disconnect();
    await this.connect(state);
  }
}
```

## Why This Happens

In serverless/distributed environments like Vercel:
1. User starts OAuth flow → Client instance A with session state `ABC123`
2. Callback happens → Handled by Client instance B (different process/container)
3. Instance B calls `finishAuth()` with state `ABC123`
4. Instance B's OAuth provider has a different state, so it creates a new session
5. New session has no `code_verifier` for the authorization code
6. PKCE validation fails

The fix ensures the client adopts the existing session rather than creating a new one during the callback phase.